### PR TITLE
feat: support aws_partition for govcloud

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,9 @@
 locals {
   irsa_role_create = var.enabled && var.service_account_create && var.irsa_role_create
+  partition        = data.aws_partition.current.id
 }
+
+data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "this" {
   count = local.irsa_role_create && var.irsa_policy_enabled ? 1 : 0
@@ -98,7 +101,7 @@ data "aws_iam_policy_document" "this" {
     actions = [
       "ec2:CreateTags"
     ]
-    resources = ["arn:aws:ec2:*:*:security-group/*"]
+    resources = ["arn:${local.partition}:ec2:*:*:security-group/*"]
     condition {
       test     = "StringEquals"
       variable = "ec2:CreateAction"
@@ -117,7 +120,7 @@ data "aws_iam_policy_document" "this" {
       "ec2:CreateTags",
       "ec2:DeleteTags"
     ]
-    resources = ["arn:aws:ec2:*:*:security-group/*"]
+    resources = ["arn:${local.partition}:ec2:*:*:security-group/*"]
     condition {
       test     = "Null"
       variable = "aws:RequestTag/elbv2.k8s.aws/cluster"
@@ -177,9 +180,9 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:RemoveTags"
     ]
     resources = [
-      "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      "arn:${local.partition}:elasticloadbalancing:*:*:targetgroup/*/*",
+      "arn:${local.partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+      "arn:${local.partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*"
     ]
     condition {
       test     = "Null"
@@ -200,10 +203,10 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:RemoveTags"
     ]
     resources = [
-      "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
-      "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
-      "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
-      "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+      "arn:${local.partition}:elasticloadbalancing:*:*:listener/net/*/*/*",
+      "arn:${local.partition}:elasticloadbalancing:*:*:listener/app/*/*/*",
+      "arn:${local.partition}:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+      "arn:${local.partition}:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
     ]
   }
 
@@ -233,7 +236,7 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:RegisterTargets",
       "elasticloadbalancing:DeregisterTargets"
     ]
-    resources = ["arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"]
+    resources = ["arn:${local.partition}:elasticloadbalancing:*:*:targetgroup/*/*"]
   }
 
   statement {


### PR DESCRIPTION
# Description

Add support for govcloud regions in IAM policy via aws partition. This method is also referenced here: https://github.com/terraform-aws-modules/terraform-aws-iam/issues/226

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

Terraform plan/apply in a govcloud account.
