### PR TITLE
feat: Adding elasticloadbalancing:AddTags action persmission for statements with Create API

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.13.0"
+  version = "4.0.0"
 
   name               = "lb_controller-vpc"
   cidr               = "10.0.0.0/16"

--- a/iam.tf
+++ b/iam.tf
@@ -149,7 +149,8 @@ data "aws_iam_policy_document" "this" {
     effect = "Allow"
     actions = [
       "elasticloadbalancing:CreateLoadBalancer",
-      "elasticloadbalancing:CreateTargetGroup"
+      "elasticloadbalancing:CreateTargetGroup",
+      "elasticloadbalancing:AddTags"
     ]
     resources = ["*"]
     condition {
@@ -165,7 +166,8 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:CreateListener",
       "elasticloadbalancing:DeleteListener",
       "elasticloadbalancing:CreateRule",
-      "elasticloadbalancing:DeleteRule"
+      "elasticloadbalancing:DeleteRule",
+      "elasticloadbalancing:AddTags"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
# Description

Based on AWS notification adding elasticloadbalancing AddTags action permissions within iam statements where Create* API call is used.

![image](https://github.com/lablabs/terraform-aws-eks-load-balancer-controller/assets/32060624/a2723db0-a577-49b2-a8e8-94766bddf308)


<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

Verified by adding missing tags within client infrastructure.

<!--
Please describe the tests that you ran to verify your changes.
-->
