### PR TITLE
feat: Add Support for EKS Pod Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Create helm release resource and deploy it as argo application (set `enabled = t
 
 ## AWS IAM resources
 
-To disable of creation IRSA role and IRSA policy, set `irsa_role_create = false` and `irsa_policy_enabled = false`, respectively
+To enable the creation of the EKS Pod Identity role and policy, set `eks_pod_identity_role_create = false` and `eks_pod_identity_policy_enabled = false`, respectively.
+To disable the creation of IRSA role and IRSA policy, set `irsa_role_create = false` and `irsa_policy_enabled = false`, respectively.
 
 ## Examples
 
@@ -60,12 +61,17 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_eks_pod_identity_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
+| [aws_iam_policy.eks_pod_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.eks_pod_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.eks_pod_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.argo_application](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_manifest.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [aws_iam_policy_document.eks_pod_identity_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [utils_deep_merge_yaml.argo_helm_values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
@@ -94,6 +100,10 @@ No modules.
 | <a name="input_argo_spec"></a> [argo\_spec](#input\_argo\_spec) | ArgoCD Application spec configuration. Override or create additional spec parameters | `any` | `{}` | no |
 | <a name="input_argo_sync_policy"></a> [argo\_sync\_policy](#input\_argo\_sync\_policy) | ArgoCD syncPolicy manifest parameter | `any` | `{}` | no |
 | <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | AWS partition in which the resources are located. Available values are `aws`, `aws-cn`, `aws-us-gov` | `string` | `"aws"` | no |
+| <a name="input_eks_pod_identity_policy_enabled"></a> [eks\_pod\_identity\_policy\_enabled](#input\_eks\_pod\_identity\_policy\_enabled) | Whether to create opinionated policy for LB controller, see https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.4.0/docs/install/iam_policy.json | `bool` | `true` | no |
+| <a name="input_eks_pod_identity_role_create"></a> [eks\_pod\_identity\_role\_create](#input\_eks\_pod\_identity\_role\_create) | Determines whether to enable support for the EKS pod identity | `bool` | `false` | no |
+| <a name="input_eks_pod_identity_role_name_prefix"></a> [eks\_pod\_identity\_role\_name\_prefix](#input\_eks\_pod\_identity\_role\_name\_prefix) | The EKS pod identity role name prefix for LB controller | `string` | `"lb-controller-pod-identity"` | no |
+| <a name="input_eks_pod_identity_tags"></a> [eks\_pod\_identity\_tags](#input\_eks\_pod\_identity\_tags) | The EKS Pod identity resources tags | `map(string)` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_atomic"></a> [helm\_atomic](#input\_helm\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used | `bool` | `false` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"aws-load-balancer-controller"` | no |
@@ -105,6 +115,7 @@ No modules.
 | <a name="input_helm_devel"></a> [helm\_devel](#input\_helm\_devel) | Use helm chart development versions, too. Equivalent to version '>0.0.0-0'. If version is set, this is ignored | `bool` | `false` | no |
 | <a name="input_helm_disable_openapi_validation"></a> [helm\_disable\_openapi\_validation](#input\_helm\_disable\_openapi\_validation) | If set, the installation process will not validate rendered helm templates against the Kubernetes OpenAPI Schema | `bool` | `false` | no |
 | <a name="input_helm_disable_webhooks"></a> [helm\_disable\_webhooks](#input\_helm\_disable\_webhooks) | Prevent helm chart hooks from running | `bool` | `false` | no |
+| <a name="input_helm_enabled"></a> [helm\_enabled](#input\_helm\_enabled) | Determines if the helm chart should be installed | `bool` | `true` | no |
 | <a name="input_helm_force_update"></a> [helm\_force\_update](#input\_helm\_force\_update) | Force helm resource update through delete/recreate if needed | `bool` | `false` | no |
 | <a name="input_helm_keyring"></a> [helm\_keyring](#input\_helm\_keyring) | Location of public keys used for verification. Used only if helm\_package\_verify is true | `string` | `"~/.gnupg/pubring.gpg"` | no |
 | <a name="input_helm_lint"></a> [helm\_lint](#input\_helm\_lint) | Run the helm chart linter during the plan | `bool` | `false` | no |

--- a/eks_pod_identity.tf
+++ b/eks_pod_identity.tf
@@ -1,0 +1,56 @@
+locals {
+  eks_pod_identity_role_create = var.enabled && var.service_account_create && var.eks_pod_identity_role_create
+}
+
+resource "aws_iam_policy" "eks_pod_identity" {
+  count       = local.eks_pod_identity_role_create && var.eks_pod_identity_policy_enabled ? 1 : 0
+  name        = "${var.eks_pod_identity_role_name_prefix}-${var.helm_release_name}"
+  path        = "/"
+  description = "Policy for aws-load-balancer-controller service"
+
+  policy = data.aws_iam_policy_document.this[0].json
+  tags   = var.eks_pod_identity_tags
+}
+
+data "aws_iam_policy_document" "eks_pod_identity_assume" {
+  count = local.eks_pod_identity_role_create ? 1 : 0
+
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "eks_pod_identity" {
+  count = local.eks_pod_identity_role_create ? 1 : 0
+
+  name               = "${var.eks_pod_identity_role_name_prefix}-${var.helm_release_name}"
+  assume_role_policy = data.aws_iam_policy_document.eks_pod_identity_assume[0].json
+
+  tags = var.eks_pod_identity_tags
+}
+
+resource "aws_iam_role_policy_attachment" "eks_pod_identity" {
+  count = local.eks_pod_identity_role_create ? 1 : 0
+
+  role       = aws_iam_role.eks_pod_identity[0].name
+  policy_arn = aws_iam_policy.eks_pod_identity[0].arn
+}
+
+resource "aws_eks_pod_identity_association" "this" {
+  count = local.eks_pod_identity_role_create ? 1 : 0
+
+  cluster_name    = var.cluster_name
+  namespace       = var.namespace
+  service_account = var.service_account_name
+  role_arn        = aws_iam_role.eks_pod_identity[0].arn
+}

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -22,6 +22,7 @@ The code in this example shows how to use the module with basic configuration an
 | <a name="module_lb_controller_argo_kubernetes"></a> [lb\_controller\_argo\_kubernetes](#module\_lb\_controller\_argo\_kubernetes) | ../../ | n/a |
 | <a name="module_lb_controller_helm"></a> [lb\_controller\_helm](#module\_lb\_controller\_helm) | ../../ | n/a |
 | <a name="module_lbc_disabled"></a> [lbc\_disabled](#module\_lbc\_disabled) | ../../ | n/a |
+| <a name="module_lbc_with_eks_pod_identity_role"></a> [lbc\_with\_eks\_pod\_identity\_role](#module\_lbc\_with\_eks\_pod\_identity\_role) | ../../ | n/a |
 | <a name="module_lbc_without_irsa_policy"></a> [lbc\_without\_irsa\_policy](#module\_lbc\_without\_irsa\_policy) | ../../ | n/a |
 | <a name="module_lbc_without_irsa_role"></a> [lbc\_without\_irsa\_role](#module\_lbc\_without\_irsa\_role) | ../../ | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.5.1 |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -62,6 +62,16 @@ module "lbc_without_irsa_policy" {
   cluster_identity_oidc_issuer_arn = module.eks_cluster.eks_cluster_identity_oidc_issuer_arn
 }
 
+module "lbc_with_eks_pod_identity_role" {
+  source = "../../"
+
+  eks_pod_identity_role_create     = true
+  irsa_role_create                 = false
+  cluster_name                     = module.eks_cluster.eks_cluster_id
+  cluster_identity_oidc_issuer     = module.eks_cluster.eks_cluster_identity_oidc_issuer
+  cluster_identity_oidc_issuer_arn = module.eks_cluster.eks_cluster_identity_oidc_issuer_arn
+
+}
 
 module "lb_controller_helm" {
   source = "../../"

--- a/iam.tf
+++ b/iam.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 data "aws_iam_policy_document" "this" {
-  count = local.irsa_role_create && var.irsa_policy_enabled ? 1 : 0
+  count = (local.irsa_role_create && var.irsa_policy_enabled) || (local.eks_pod_identity_role_create && var.eks_pod_identity_policy_enabled) ? 1 : 0
 
   # https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.10.1/docs/install/iam_policy.json
   #checkov:skip=CKV_AWS_109:The official documentation was used to define these policies

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,30 @@ variable "service_account_name" {
   description = "The k8s aws-loab-balancer-controller service account name"
 }
 
+variable "eks_pod_identity_role_create" {
+  type        = bool
+  default     = false
+  description = "Determines whether to enable support for the EKS pod identity"
+}
+
+variable "eks_pod_identity_role_name_prefix" {
+  type        = string
+  default     = "lb-controller-pod-identity"
+  description = "The EKS pod identity role name prefix for LB controller"
+}
+
+variable "eks_pod_identity_policy_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether to create opinionated policy for LB controller, see https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.4.0/docs/install/iam_policy.json"
+}
+
+variable "eks_pod_identity_tags" {
+  type        = map(string)
+  default     = {}
+  description = "The EKS Pod identity resources tags"
+}
+
 variable "irsa_role_create" {
   type        = bool
   default     = true


### PR DESCRIPTION
This pull request implements a new feature to add support for EKS Pod Identity as requested in issue #19 

#### Summary
This pull request introduces support for EKS Pod Identity in the module. The changes include the addition of new variables, resources, and documentation updates to enable the creation of Pod Identity roles and policies.

#### Changes
1. **Documentation Updates**:
   - Added instructions for enabling Pod Identity role and policy in README.md
   - Updated examples in README.md to include a new module configuration for Pod Identity.

2. **New Resources**:
   - Created eks_pod_identity.tf to define IAM resources for Pod Identity, including:
     - `aws_iam_policy.eks_pod_identity`
     - `aws_iam_role.eks_pod_identity`
     - `aws_iam_role_policy_attachment.eks_pod_identity`
     - `aws_iam_policy_document.eks_pod_identity_assume`
     - `aws_eks_pod_identity_association.this`

3. **Examples**:
   - Added a new example configuration `lbc_with_eks_pod_identity_role` in main.tf.

4. **Variables**:
   - Added new variables in variables.tf to support Pod Identity:
     - `eks_pod_identity_role_create`
     - `eks_pod_identity_role_name_prefix`
     - `eks_pod_identity_policy_enabled`
     - `eks_pod_identity_tags`

#### Impact
- These changes do not break existing functionality.
- Users can now enable Pod Identity support by setting the appropriate variables.

#### How to Test
- Follow the updated instructions in the README.md to enable Pod Identity.
- Use the new example configuration in main.tf to test the Pod Identity setup.

#### Notes
- Ensure that the AWS IAM permissions are correctly configured to allow the creation of the new IAM resources.

Closes #19 

Please review the changes and provide feedback.