### PR TITLE
feat: Update IAM Policy ARNs to Use aws_partition Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ No modules.
 | <a name="input_argo_project"></a> [argo\_project](#input\_argo\_project) | ArgoCD Application project | `string` | `"default"` | no |
 | <a name="input_argo_spec"></a> [argo\_spec](#input\_argo\_spec) | ArgoCD Application spec configuration. Override or create additional spec parameters | `any` | `{}` | no |
 | <a name="input_argo_sync_policy"></a> [argo\_sync\_policy](#input\_argo\_sync\_policy) | ArgoCD syncPolicy manifest parameter | `any` | `{}` | no |
+| <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | AWS partition in which the resources are located. Available values are `aws`, `aws-cn`, `aws-us-gov` | `string` | `"aws"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_atomic"></a> [helm\_atomic](#input\_helm\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used | `bool` | `false` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"aws-load-balancer-controller"` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -101,7 +101,7 @@ data "aws_iam_policy_document" "this" {
     actions = [
       "ec2:CreateTags"
     ]
-    resources = ["arn:aws:ec2:*:*:security-group/*"]
+    resources = ["arn:${var.aws_partition}:ec2:*:*:security-group/*"]
     condition {
       test     = "StringEquals"
       variable = "ec2:CreateAction"
@@ -120,7 +120,7 @@ data "aws_iam_policy_document" "this" {
       "ec2:CreateTags",
       "ec2:DeleteTags"
     ]
-    resources = ["arn:aws:ec2:*:*:security-group/*"]
+    resources = ["arn:${var.aws_partition}:ec2:*:*:security-group/*"]
     condition {
       test     = "Null"
       variable = "aws:RequestTag/elbv2.k8s.aws/cluster"
@@ -180,9 +180,9 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:RemoveTags"
     ]
     resources = [
-      "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:targetgroup/*/*",
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*"
     ]
     condition {
       test     = "Null"
@@ -203,10 +203,10 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:RemoveTags"
     ]
     resources = [
-      "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
-      "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
-      "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
-      "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:listener/net/*/*/*",
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:listener/app/*/*/*",
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
     ]
   }
 
@@ -216,9 +216,9 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:AddTags"
     ]
     resources = [
-      "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-      "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:targetgroup/*/*",
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+      "arn:${var.aws_partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*"
     ]
     condition {
       test     = "StringEquals"
@@ -263,7 +263,7 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:RegisterTargets",
       "elasticloadbalancing:DeregisterTargets"
     ]
-    resources = ["arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"]
+    resources = ["arn:${var.aws_partition}:elasticloadbalancing:*:*:targetgroup/*/*"]
   }
 
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -378,3 +378,9 @@ variable "helm_lint" {
   default     = false
   description = "Run the helm chart linter during the plan"
 }
+
+variable "aws_partition" {
+  type        = string
+  default     = "aws"
+  description = "AWS partition in which the resources are located. Available values are `aws`, `aws-cn`, `aws-us-gov`"
+}


### PR DESCRIPTION
**Title:**
Update IAM Policy ARNs to Use aws_partition Variable

**Description:**
This pull request updates the IAM policy ARNs in the Terraform configuration to use the `aws_partition` variable. This change ensures that the ARNs are dynamically generated based on the specified AWS partition, enhancing compatibility across different AWS environments such as AWS GovCloud and AWS China.

**Changes:**
- Added a new variable `aws_partition` in `variables.tf` with a default value of `aws`.
- Updated ARNs in the IAM policy document to use `${var.aws_partition}` instead of hardcoding `aws`.

These updates improve the flexibility and portability of the Terraform configuration, making it more adaptable to various AWS partitions.

Closes #17 
Supersedes #18  