### PR TITLE
feat(iam): update iam policy to be compatible version 2.11.0 of lb-controller

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2022] [Labyrinth Labs]
+   Copyright [2025] [Labyrinth Labs]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/iam.tf
+++ b/iam.tf
@@ -5,7 +5,7 @@ locals {
 data "aws_iam_policy_document" "this" {
   count = (local.irsa_role_create && var.irsa_policy_enabled) || (local.eks_pod_identity_role_create && var.eks_pod_identity_policy_enabled) ? 1 : 0
 
-  # https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.10.1/docs/install/iam_policy.json
+  # https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.11.0/docs/install/iam_policy.json
   #checkov:skip=CKV_AWS_109:The official documentation was used to define these policies
   #checkov:skip=CKV_AWS_111:The official documentation was used to define these policies
   #checkov:skip=CKV_AWS_356
@@ -50,7 +50,8 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:DescribeTargetGroupAttributes",
       "elasticloadbalancing:DescribeTargetHealth",
       "elasticloadbalancing:DescribeTags",
-      "elasticloadbalancing:DescribeTrustStores"
+      "elasticloadbalancing:DescribeTrustStores",
+      "elasticloadbalancing:DescribeCapacityReservation"
     ]
     resources = ["*"]
   }
@@ -247,7 +248,8 @@ data "aws_iam_policy_document" "this" {
       "elasticloadbalancing:DeleteLoadBalancer",
       "elasticloadbalancing:ModifyTargetGroup",
       "elasticloadbalancing:ModifyTargetGroupAttributes",
-      "elasticloadbalancing:DeleteTargetGroup"
+      "elasticloadbalancing:DeleteTargetGroup",
+      "elasticloadbalancing:ModifyCapacityReservation"
     ]
     resources = ["*"]
     condition {


### PR DESCRIPTION
Hello,
me again :)

Another policy change is needed to use the 2.11.0 version of the load balancer controller.

# Description

- update IAM policy document according to official [docs](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.11.0/docs/install/iam_policy.json)
- this is not a breaking change just an option to upgrade to 2.11.0

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

deployment of the controller + deployment of testing app