### PR TITLE
Allow user to add additonal IAM policy

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -287,8 +287,15 @@ resource "aws_iam_policy" "this" {
   path        = "/"
   description = "Policy for aws-load-balancer-controller service"
 
-  policy = data.aws_iam_policy_document.this[0].json
+  policy = data.aws_iam_policy_document.combine_additional_policy.json
   tags   = var.irsa_tags
+}
+
+data "aws_iam_policy_document" "combine_additional_policy" {
+  source_policy_documents   = [
+    data.aws_iam_policy_document.this[0].json,
+    var.additional_iam_policy
+  ]
 }
 
 data "aws_iam_policy_document" "this_assume" {

--- a/variables.tf
+++ b/variables.tf
@@ -408,3 +408,9 @@ variable "aws_partition" {
   default     = "aws"
   description = "AWS partition in which the resources are located. Available values are `aws`, `aws-cn`, `aws-us-gov`"
 }
+
+variable "additional_iam_policy" {
+  type        = string
+  default     = "{}"
+  description = "Allow to Update additional IAM policy for aws-load-balancer-controller service."
+}


### PR DESCRIPTION
# Description

Add enhancements to issue >  https://github.com/lablabs/terraform-aws-eks-load-balancer-controller/pull/26#issue-2955353556

`
User: arn:aws:sts::aws-acc-id:assumed-role/irsa-k8s-alb-prod/1744547382731549898 is not authorized to perform: 
elasticloadbalancing:SetRulePriorities on resource: arn:aws:elasticloadbalancing:ap-south-1:aws-acc-id:listener-rule/app/alb-prod/8db67800d053e98e/cb6e3eb9b0d22f03/d7bf97040d690e46 because no identity-based policy allows the elasticloadbalancing:SetRulePriorities action
`

to pass into module:
```
data "aws_iam_policy_document" "alb_additional_iam_policy" {
  statement {
    effect = "Allow"
    actions = [
      "elasticloadbalancing:SetRulePriorities",
    ]
    resources = ["*"]
  }
}

## input variable
additional_iam_policy = data.aws_iam_policy_document.alb_additional_iam_policy.json

```
Changes on IAM policies with this PR 

```
{
      Action   = [
          "elasticloadbalancing:SetWebAcl",
          "elasticloadbalancing:RemoveListenerCertificates",
          "elasticloadbalancing:ModifyRule",
          "elasticloadbalancing:ModifyListener",
          "elasticloadbalancing:AddListenerCertificates",
      ]
      Effect   = "Allow"
      Resource = "*"
    },
  + {
      + Action   = "elasticloadbalancing:SetRulePriorities"
      + Effect   = "Allow"
      + Resource = "*"
    },
]
}
```

- We should allow use to pass additional IAM policy so that we dont block user with AWS changes to future policies.
- use combine method to add new policies https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

Yes, added a terraform plan in PR description.
<!--
Please describe the tests that you ran to verify your changes.
-->
